### PR TITLE
feat: add graceful shutdown handler (fixes #90)

### DIFF
--- a/src/__tests__/shutdown.test.js
+++ b/src/__tests__/shutdown.test.js
@@ -1,0 +1,107 @@
+process.env.NODE_ENV = 'test';
+
+jest.mock('../models/db', () => jest.fn());
+jest.mock('../services/accountService', () => ({
+  list: jest.fn(),
+  getById: jest.fn(),
+  create: jest.fn(),
+}));
+jest.mock('../services/transactionService', () => ({
+  list: jest.fn(),
+  getById: jest.fn(),
+  transfer: jest.fn(),
+}));
+jest.mock('../services/paymentService', () => ({
+  process: jest.fn(),
+  refund: jest.fn(),
+  getHistory: jest.fn(),
+}));
+jest.mock('../services/userService', () => ({
+  register: jest.fn(),
+  login: jest.fn(),
+  getProfile: jest.fn(),
+}));
+jest.mock('../utils/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+const { logger } = require('../utils/logger');
+
+describe('Graceful shutdown handler', () => {
+  let exitSpy;
+
+  beforeEach(() => {
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  it('calls server.close and exits with 0 on SIGTERM when server is running', (done) => {
+    const app = require('../index');
+    const { gracefulShutdown, _setServer } = app;
+
+    const mockServer = {
+      close: jest.fn((cb) => cb()),
+    };
+    _setServer(mockServer);
+
+    gracefulShutdown('SIGTERM');
+
+    expect(logger.info).toHaveBeenCalledWith('SIGTERM received. Starting graceful shutdown...');
+    expect(mockServer.close).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('Server closed. All pending requests completed.');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    _setServer(null);
+    done();
+  });
+
+  it('calls server.close and exits with 0 on SIGINT when server is running', (done) => {
+    const app = require('../index');
+    const { gracefulShutdown, _setServer } = app;
+
+    const mockServer = {
+      close: jest.fn((cb) => cb()),
+    };
+    _setServer(mockServer);
+
+    gracefulShutdown('SIGINT');
+
+    expect(logger.info).toHaveBeenCalledWith('SIGINT received. Starting graceful shutdown...');
+    expect(mockServer.close).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    _setServer(null);
+    done();
+  });
+
+  it('exits immediately with 0 when no server is running', () => {
+    const app = require('../index');
+    const { gracefulShutdown, _setServer } = app;
+
+    _setServer(null);
+
+    gracefulShutdown('SIGTERM');
+
+    expect(logger.info).toHaveBeenCalledWith('SIGTERM received. Starting graceful shutdown...');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('logs the correct signal name in shutdown message', () => {
+    const app = require('../index');
+    const { gracefulShutdown, _setServer } = app;
+
+    _setServer(null);
+
+    gracefulShutdown('SIGTERM');
+    expect(logger.info).toHaveBeenCalledWith('SIGTERM received. Starting graceful shutdown...');
+
+    jest.clearAllMocks();
+
+    gracefulShutdown('SIGINT');
+    expect(logger.info).toHaveBeenCalledWith('SIGINT received. Starting graceful shutdown...');
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,26 @@ app.use('/v1', apiRouter);
 app.get('/health', (req, res) => res.json({ status: 'ok' }));
 
 const PORT = process.env.PORT || 3000;
+let server;
 if (process.env.NODE_ENV !== 'test') {
-  app.listen(PORT, () => logger.info(`FinSecure running on port ${PORT}`));
+  server = app.listen(PORT, () => logger.info(`FinSecure running on port ${PORT}`));
 }
+
+function gracefulShutdown(signal) {
+  logger.info(`${signal} received. Starting graceful shutdown...`);
+  if (server) {
+    server.close(() => {
+      logger.info('Server closed. All pending requests completed.');
+      process.exit(0);
+    });
+  } else {
+    process.exit(0);
+  }
+}
+
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+
 module.exports = app;
+module.exports.gracefulShutdown = gracefulShutdown;
+module.exports._setServer = (s) => { server = s; };


### PR DESCRIPTION
## Summary
Resolves #90. Adds graceful shutdown handling for SIGTERM and SIGINT signals so the server can finish processing active requests before exiting.

## Changes
- **`src/index.js`**: Store the server reference from `app.listen()`, add a `gracefulShutdown()` function that logs the signal, calls `server.close()` to stop accepting new connections and wait for in-flight requests, then exits cleanly with code 0. Registers handlers for both `SIGTERM` and `SIGINT`.
- **`src/__tests__/shutdown.test.js`**: New test suite with 4 tests covering:
  - SIGTERM with active server closes gracefully
  - SIGINT with active server closes gracefully
  - Immediate exit when no server is running
  - Correct signal name in log messages

## Testing
All 28 tests pass (24 existing + 4 new).

---
[Devin session](https://app.devin.ai/sessions/bedc77577f70419aa6f0308ee1d4cf2a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/febuniac/finserv/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
