### PR TITLE
feat: add environment variable validation at startup

### DIFF
--- a/src/__tests__/validateEnv.test.js
+++ b/src/__tests__/validateEnv.test.js
@@ -1,0 +1,45 @@
+describe('validateEnv', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('throws when DB_HOST is missing', () => {
+    delete process.env.DB_HOST;
+    process.env.JWT_SECRET = 'test-secret';
+    const { validateEnv } = require('../utils/validateEnv');
+    expect(() => validateEnv()).toThrow('Missing required environment variables: DB_HOST');
+  });
+
+  it('throws when JWT_SECRET is missing', () => {
+    process.env.DB_HOST = 'localhost';
+    delete process.env.JWT_SECRET;
+    const { validateEnv } = require('../utils/validateEnv');
+    expect(() => validateEnv()).toThrow('Missing required environment variables: JWT_SECRET');
+  });
+
+  it('throws when multiple env vars are missing', () => {
+    delete process.env.DB_HOST;
+    delete process.env.JWT_SECRET;
+    const { validateEnv } = require('../utils/validateEnv');
+    expect(() => validateEnv()).toThrow('Missing required environment variables: DB_HOST, JWT_SECRET');
+  });
+
+  it('does not throw when all required env vars are set', () => {
+    process.env.DB_HOST = 'localhost';
+    process.env.JWT_SECRET = 'test-secret';
+    const { validateEnv } = require('../utils/validateEnv');
+    expect(() => validateEnv()).not.toThrow();
+  });
+
+  it('exports REQUIRED_ENV_VARS array', () => {
+    const { REQUIRED_ENV_VARS } = require('../utils/validateEnv');
+    expect(REQUIRED_ENV_VARS).toEqual(['DB_HOST', 'JWT_SECRET']);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,11 @@ const express = require('express');
 const helmet = require('helmet');
 const cors = require('cors');
 const { logger } = require('./utils/logger');
+const { validateEnv } = require('./utils/validateEnv');
+
+if (process.env.NODE_ENV !== 'test') {
+  validateEnv();
+}
 
 const app = express();
 app.use(helmet());

--- a/src/utils/validateEnv.js
+++ b/src/utils/validateEnv.js
@@ -1,0 +1,10 @@
+const REQUIRED_ENV_VARS = ['DB_HOST', 'JWT_SECRET'];
+
+function validateEnv() {
+  const missing = REQUIRED_ENV_VARS.filter(v => !process.env[v]);
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+  }
+}
+
+module.exports = { validateEnv, REQUIRED_ENV_VARS };


### PR DESCRIPTION
## Summary
Fixes #95 — The app previously started even when required environment variables were missing.

## Changes
- Added `src/utils/validateEnv.js` that checks for required env vars (`DB_HOST`, `JWT_SECRET`) at startup and throws a descriptive error if any are missing
- Updated `src/index.js` to call `validateEnv()` before app initialization (skipped in test environment)
- Added comprehensive tests in `src/__tests__/validateEnv.test.js` covering: missing single var, missing multiple vars, all vars present, and exports verification

## Test Results
All 29 tests pass with 100% coverage on the new `validateEnv.js` module.

[Devin session](https://app.devin.ai/sessions/277a114c4a0f45238ecfb2c3c64dcedf)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/febuniac/finserv/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
